### PR TITLE
Introduce `eligibility_authority` to claimable yield

### DIFF
--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -161,7 +161,7 @@ pub struct InitializeInstructionData {
     /// The public key for the account which has the right to claim accrued yield for any token accounts not flagged as yield eligible. If None, any yield accrued to ineligible accounts will be lost.
     pub claim_authority: OptionalNonZeroPubkey,
     /// The public key for the account which has authority over which accounts can claim yield. If None, token account owners may always opt in/out of yield claiming.
-    pub yield_authority: OptionalNonZeroPubkey,
+    pub eligibility_authority: OptionalNonZeroPubkey,
     /// The public key for the account that can update the global index
     pub index_authority: OptionalNonZeroPubkey,
     /// The initial global index value (fixed-point with 9 decimal places)
@@ -183,7 +183,7 @@ pub fn initialize_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     claim_authority: Option<Pubkey>,
-    yield_authority: Option<Pubkey>,
+    eligibility_authority: Option<Pubkey>,
     index_authority: Option<Pubkey>,
     initial_index: u64,
 ) -> Result<Instruction, ProgramError> {
@@ -196,7 +196,7 @@ pub fn initialize_mint(
         ClaimableYieldInstruction::InitializeMint,
         &InitializeInstructionData {
             claim_authority: claim_authority.try_into()?,
-            yield_authority: yield_authority.try_into()?,
+            eligibility_authority: eligibility_authority.try_into()?,
             index_authority: index_authority.try_into()?,
             initial_index: initial_index.into(),
         },
@@ -208,14 +208,14 @@ pub fn enable_yield(
     token_program_id: &Pubkey,
     account: &Pubkey,
     mint: &Pubkey,
-    yield_authority: &Pubkey,
+    eligibility_authority: &Pubkey,
     signers: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+        AccountMeta::new_readonly(*eligibility_authority, signers.is_empty()),
     ];
     for signer_pubkey in signers.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
@@ -234,14 +234,14 @@ pub fn disable_yield(
     token_program_id: &Pubkey,
     account: &Pubkey,
     mint: &Pubkey,
-    yield_authority: &Pubkey,
+    eligibility_authority: &Pubkey,
     signers: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+        AccountMeta::new_readonly(*eligibility_authority, signers.is_empty()),
     ];
     for signer_pubkey in signers.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -110,73 +110,41 @@ pub enum ClaimableYieldInstruction {
     ///   `crate::extension::claimable_yield::instruction::UpdateIndexInstructionData`
     UpdateIndex,
 
-    /// Claim all accrued yield for a yield-eligible token account.
+    /// Claim all accrued yield for a token account to a target account.
     ///
-    /// This instruction allows the token account owner to claim their own yield
-    /// if the account has been marked as yield-eligible by the yield authority.
-    ///
-    /// This instruction performs both soft and hard claims in a single operation:
-    /// 1. Calculates all unclaimed yield based on the current global index
-    /// 2. Adds any existing pending amount to the calculated yield
-    /// 3. Mints new tokens equal to the total yield amount
-    /// 4. Adds the minted tokens to the account's spendable balance
-    /// 5. Updates the account's local index to the current global index
-    /// 6. Resets the pending amount to zero
-    ///
-    /// The account extension must already be configured for claimable yield.
-    /// Fails if:
-    /// - The account is not yield-eligible
-    /// - The signer is not the token account owner
-    ///
-    /// Accounts expected by this instruction:
-    ///
-    ///   * Single owner
-    ///   0. `[writable]` The token account to claim yield for.
-    ///   1. `[writable]` The mint account (to increase supply).
-    ///   2. `[signer]` The token account owner.
-    ///
-    ///   * Multisignature owner
-    ///   0. `[writable]` The token account to claim yield for.
-    ///   1. `[writable]` The mint account.
-    ///   2. `[]` The token account's multisignature owner.
-    ///   3. `..3+M` `[signer]` M signer accounts.
-    OwnerClaimYield,
-
-    /// Claim yield on behalf of a non-eligible token account.
-    ///
-    /// This instruction allows the yield authority to claim yield for token accounts
-    /// that have not been marked as yield-eligible. The yield is accrued to a specified
-    /// target token account.
+    /// This instruction allows claiming yield with dynamic signer authorization:
+    /// - If the source account is yield-eligible, the token account owner must sign
+    /// - If the source account is not yield-eligible, the mint's yield authority must sign
     ///
     /// This instruction performs both soft and hard claims in a single operation:
     /// 1. Calculates all unclaimed yield based on the current global index
     /// 2. Adds any existing pending amount to the calculated yield
     /// 3. Mints new tokens equal to the total yield amount
-    /// 4. Adds the minted tokens to the target account's spendable balance
+    /// 4. Adds the minted tokens to the target account's balance
     /// 5. Updates the source account's local index to the current global index
     /// 6. Resets the source account's pending amount to zero
     ///
     /// Fails if:
-    /// - No yield authority is set on the mint
-    /// - The source account is yield-eligible (should use OwnerClaimYield instead)
-    /// - The signer is not the yield authority
-    /// - The target account does not belong to the same mint
+    /// - Source account is yield-eligible but the signer is not the token account owner
+    /// - Source account is not yield-eligible and no yield authority is set on the mint
+    /// - Source account is not yield-eligible but the signer is not the yield authority
+    /// - Target account does not belong to the same mint
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   * Single authority
+    ///   * Single signer (owner or yield authority)
     ///   0. `[writable]` The source token account to claim yield from.
-    ///   1. `[writable]` The target token account to accrue yield to.
+    ///   1. `[writable]` The target token account to receive the minted tokens.
     ///   2. `[writable]` The mint account (to increase supply).
-    ///   3. `[signer]` The mint's yield authority.
+    ///   3. `[signer]` The owner (if yield-eligible) or yield authority (if not).
     ///
-    ///   * Multisignature authority
+    ///   * Multisignature signer
     ///   0. `[writable]` The source token account to claim yield from.
-    ///   1. `[writable]` The target token account to accrue yield to.
+    ///   1. `[writable]` The target token account to receive the minted tokens.
     ///   2. `[writable]` The mint account.
-    ///   3. `[]` The mint's multisignature yield authority.
+    ///   3. `[]` The multisignature owner or yield authority.
     ///   4. `..4+M` `[signer]` M signer accounts.
-    AuthorityClaimYield,
+    ClaimYieldTo,
 }
 
 /// Data expected by `ClaimableYieldInstruction::InitializeMint`
@@ -305,39 +273,13 @@ pub fn update_index(
     ))
 }
 
-/// Create an `OwnerClaimYield` instruction
-pub fn owner_claim_yield(
-    token_program_id: &Pubkey,
-    account: &Pubkey,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    signers: &[&Pubkey],
-) -> Result<Instruction, ProgramError> {
-    check_program_account(token_program_id)?;
-    let mut accounts = vec![
-        AccountMeta::new(*account, false),
-        AccountMeta::new(*mint, false), // Mint needs to be writable for supply update
-        AccountMeta::new_readonly(*owner, signers.is_empty()),
-    ];
-    for signer_pubkey in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
-    }
-    Ok(encode_instruction(
-        token_program_id,
-        accounts,
-        TokenInstruction::ClaimableYieldExtension,
-        ClaimableYieldInstruction::OwnerClaimYield,
-        &(),
-    ))
-}
-
-/// Create an `AuthorityClaimYield` instruction
-pub fn authority_claim_yield(
+/// Create a `ClaimYieldTo` instruction
+pub fn claim_yield_to(
     token_program_id: &Pubkey,
     source_account: &Pubkey,
     target_account: &Pubkey,
     mint: &Pubkey,
-    yield_authority: &Pubkey,
+    authority: &Pubkey,
     signers: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
@@ -345,7 +287,7 @@ pub fn authority_claim_yield(
         AccountMeta::new(*source_account, false),
         AccountMeta::new(*target_account, false),
         AccountMeta::new(*mint, false), // Mint needs to be writable for supply update
-        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
     ];
     for signer_pubkey in signers.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
@@ -354,7 +296,7 @@ pub fn authority_claim_yield(
         token_program_id,
         accounts,
         TokenInstruction::ClaimableYieldExtension,
-        ClaimableYieldInstruction::AuthorityClaimYield,
+        ClaimableYieldInstruction::ClaimYieldTo,
         &(),
     ))
 }

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
 use {
     crate::{
         check_program_account,
@@ -10,7 +11,10 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
-    spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodU64},
+    spl_pod::{
+        optional_keys::OptionalNonZeroPubkey,
+        primitives::{PodBool, PodU64},
+    },
     std::convert::TryInto,
 };
 
@@ -100,7 +104,7 @@ pub enum ClaimableYieldInstruction {
     ///
     ///   0. `[writable]` The token account to claim yield for.
     ///   1. `[writable]` The mint account (to increase supply).
-    ///   2. `[signer]` The account's owner.
+    ///   2. `[signer]` The account's yield authority.
     ///
     ///   * Multisignature authority
     ///   0. `[writable]` The token account to claim yield for.
@@ -116,6 +120,8 @@ pub enum ClaimableYieldInstruction {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeInstructionData {
+    /// The public key for the account which has authority over which accounts can claim yield. If None, token account owners may always claim yield.
+    pub yield_authority: OptionalNonZeroPubkey,
     /// The public key for the account that can update the global index
     pub index_authority: OptionalNonZeroPubkey,
     /// The initial global index value (fixed-point with 9 decimal places)
@@ -132,10 +138,21 @@ pub struct UpdateIndexInstructionData {
     pub new_index: PodU64,
 }
 
+/// Data expected by `ClaimableYieldInstruction::ConfigureAccount`
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct ConfigureAccountInstructionData {
+    /// Whether the account owner is eligible to collect yield
+    pub yield_eligible: PodBool,
+}
+
 /// Create an `InitializeMint` instruction
 pub fn initialize_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
+    yield_authority: Option<Pubkey>,
     index_authority: Option<Pubkey>,
     initial_index: u64,
 ) -> Result<Instruction, ProgramError> {
@@ -147,6 +164,7 @@ pub fn initialize_mint(
         TokenInstruction::ClaimableYieldExtension,
         ClaimableYieldInstruction::InitializeMint,
         &InitializeInstructionData {
+            yield_authority: yield_authority.try_into()?,
             index_authority: index_authority.try_into()?,
             initial_index: initial_index.into(),
         },
@@ -187,6 +205,7 @@ pub fn configure_account(
     mint: &Pubkey,
     owner: &Pubkey,
     signers: &[&Pubkey],
+    yield_eligible: bool,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
@@ -202,7 +221,9 @@ pub fn configure_account(
         accounts,
         TokenInstruction::ClaimableYieldExtension,
         ClaimableYieldInstruction::ConfigureAccount,
-        &(),
+        &ConfigureAccountInstructionData {
+            yield_eligible: PodBool::from(yield_eligible),
+        },
     ))
 }
 

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -38,6 +38,31 @@ pub enum ClaimableYieldInstruction {
     ///   `crate::extension::claimable_yield::instruction::InitializeInstructionData`
     InitializeMint,
 
+    /// Enable yield eligibility for a token account.
+    ///
+    /// This instruction allows the yield authority to mark a token account as
+    /// eligible for yield claims. Once enabled, the token account owner can claim yield
+    /// directly without needing the yield authority's signature.
+    ///
+    /// Fails if:
+    /// - No yield authority is set on the mint
+    /// - The account is already yield-eligible
+    /// - The signer is not the yield authority
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The token account to enable yield for.
+    ///   1. `[]` The mint account.
+    ///   2. `[signer]` The mint's yield authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The token account to enable yield for.
+    ///   1. `[]` The mint account.
+    ///   2. `[]` The mint's multisignature yield authority.
+    ///   3. `..3+M` `[signer]` M signer accounts.
+    EnableYield,
+
     /// Update the global yield index. Only supported for mints that include the
     /// `ClaimableYield` extension.
     ///
@@ -130,6 +155,32 @@ pub fn initialize_mint(
             index_authority: index_authority.try_into()?,
             initial_index: initial_index.into(),
         },
+    ))
+}
+
+/// Create an `EnableYield` instruction
+pub fn enable_yield(
+    token_program_id: &Pubkey,
+    account: &Pubkey,
+    mint: &Pubkey,
+    yield_authority: &Pubkey,
+    signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*account, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ClaimableYieldExtension,
+        ClaimableYieldInstruction::EnableYield,
+        &{},
     ))
 }
 

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -153,7 +153,9 @@ pub enum ClaimableYieldInstruction {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeInstructionData {
-    /// The public key for the account which has authority over which accounts can claim yield. If None, token account owners may always claim yield.
+    /// The public key for the account which has the right to claim accrued yield for any token accounts not flagged as yield eligible. If None, any yield accrued to ineligible accounts will be lost.
+    pub claim_authority: OptionalNonZeroPubkey,
+    /// The public key for the account which has authority over which accounts can claim yield. If None, token account owners may always opt in/out of yield claiming.
     pub yield_authority: OptionalNonZeroPubkey,
     /// The public key for the account that can update the global index
     pub index_authority: OptionalNonZeroPubkey,
@@ -175,6 +177,7 @@ pub struct UpdateIndexInstructionData {
 pub fn initialize_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
+    claim_authority: Option<Pubkey>,
     yield_authority: Option<Pubkey>,
     index_authority: Option<Pubkey>,
     initial_index: u64,
@@ -187,6 +190,7 @@ pub fn initialize_mint(
         TokenInstruction::ClaimableYieldExtension,
         ClaimableYieldInstruction::InitializeMint,
         &InitializeInstructionData {
+            claim_authority: claim_authority.try_into()?,
             yield_authority: yield_authority.try_into()?,
             index_authority: index_authority.try_into()?,
             initial_index: initial_index.into(),

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -110,7 +110,10 @@ pub enum ClaimableYieldInstruction {
     ///   `crate::extension::claimable_yield::instruction::UpdateIndexInstructionData`
     UpdateIndex,
 
-    /// Claim all accrued yield for a token account.
+    /// Claim all accrued yield for a yield-eligible token account.
+    ///
+    /// This instruction allows the token account owner to claim their own yield
+    /// if the account has been marked as yield-eligible by the yield authority.
     ///
     /// This instruction performs both soft and hard claims in a single operation:
     /// 1. Calculates all unclaimed yield based on the current global index
@@ -121,19 +124,59 @@ pub enum ClaimableYieldInstruction {
     /// 6. Resets the pending amount to zero
     ///
     /// The account extension must already be configured for claimable yield.
+    /// Fails if:
+    /// - The account is not yield-eligible
+    /// - The signer is not the token account owner
     ///
     /// Accounts expected by this instruction:
     ///
+    ///   * Single owner
     ///   0. `[writable]` The token account to claim yield for.
     ///   1. `[writable]` The mint account (to increase supply).
-    ///   2. `[signer]` The account's yield authority.
+    ///   2. `[signer]` The token account owner.
     ///
-    ///   * Multisignature authority
+    ///   * Multisignature owner
     ///   0. `[writable]` The token account to claim yield for.
     ///   1. `[writable]` The mint account.
-    ///   2. `[]` The account's multisignature owner.
+    ///   2. `[]` The token account's multisignature owner.
     ///   3. `..3+M` `[signer]` M signer accounts.
-    ClaimYield,
+    OwnerClaimYield,
+
+    /// Claim yield on behalf of a non-eligible token account.
+    ///
+    /// This instruction allows the yield authority to claim yield for token accounts
+    /// that have not been marked as yield-eligible. The yield is accrued to a specified
+    /// target token account.
+    ///
+    /// This instruction performs both soft and hard claims in a single operation:
+    /// 1. Calculates all unclaimed yield based on the current global index
+    /// 2. Adds any existing pending amount to the calculated yield
+    /// 3. Mints new tokens equal to the total yield amount
+    /// 4. Adds the minted tokens to the target account's spendable balance
+    /// 5. Updates the source account's local index to the current global index
+    /// 6. Resets the source account's pending amount to zero
+    ///
+    /// Fails if:
+    /// - No yield authority is set on the mint
+    /// - The source account is yield-eligible (should use OwnerClaimYield instead)
+    /// - The signer is not the yield authority
+    /// - The target account does not belong to the same mint
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The source token account to claim yield from.
+    ///   1. `[writable]` The target token account to accrue yield to.
+    ///   2. `[writable]` The mint account (to increase supply).
+    ///   3. `[signer]` The mint's yield authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The source token account to claim yield from.
+    ///   1. `[writable]` The target token account to accrue yield to.
+    ///   2. `[writable]` The mint account.
+    ///   3. `[]` The mint's multisignature yield authority.
+    ///   4. `..4+M` `[signer]` M signer accounts.
+    AuthorityClaimYield,
 }
 
 /// Data expected by `ClaimableYieldInstruction::InitializeMint`
@@ -262,8 +305,8 @@ pub fn update_index(
     ))
 }
 
-/// Create a `ClaimYield` instruction
-pub fn claim_yield(
+/// Create an `OwnerClaimYield` instruction
+pub fn owner_claim_yield(
     token_program_id: &Pubkey,
     account: &Pubkey,
     mint: &Pubkey,
@@ -283,7 +326,35 @@ pub fn claim_yield(
         token_program_id,
         accounts,
         TokenInstruction::ClaimableYieldExtension,
-        ClaimableYieldInstruction::ClaimYield,
+        ClaimableYieldInstruction::OwnerClaimYield,
+        &(),
+    ))
+}
+
+/// Create an `AuthorityClaimYield` instruction
+pub fn authority_claim_yield(
+    token_program_id: &Pubkey,
+    source_account: &Pubkey,
+    target_account: &Pubkey,
+    mint: &Pubkey,
+    yield_authority: &Pubkey,
+    signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*source_account, false),
+        AccountMeta::new(*target_account, false),
+        AccountMeta::new(*mint, false), // Mint needs to be writable for supply update
+        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ClaimableYieldExtension,
+        ClaimableYieldInstruction::AuthorityClaimYield,
         &(),
     ))
 }

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -40,51 +40,56 @@ pub enum ClaimableYieldInstruction {
 
     /// Enable yield eligibility for a token account.
     ///
-    /// This instruction allows the yield authority to mark a token account as
-    /// eligible for yield claims. Once enabled, the token account owner can claim yield
-    /// directly without needing the yield authority's signature.
+    /// This instruction allows marking a token account as eligible for yield claims.
+    /// Once enabled, the token account owner can claim yield directly.
+    ///
+    /// Authorization:
+    /// - If a yield authority is set on the mint, the yield authority must sign
+    /// - If no yield authority is set, the token account owner must sign
     ///
     /// Fails if:
-    /// - No yield authority is set on the mint
     /// - The account is already yield-eligible
-    /// - The signer is not the yield authority
+    /// - The signer is not the required authority (yield authority or owner)
     ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single authority
     ///   0. `[writable]` The token account to enable yield for.
     ///   1. `[]` The mint account.
-    ///   2. `[signer]` The mint's yield authority.
+    ///   2. `[signer]` The yield authority (if set) or token account owner (if not).
     ///
     ///   * Multisignature authority
     ///   0. `[writable]` The token account to enable yield for.
     ///   1. `[]` The mint account.
-    ///   2. `[]` The mint's multisignature yield authority.
+    ///   2. `[]` The multisignature yield authority or token account owner.
     ///   3. `..3+M` `[signer]` M signer accounts.
     EnableYield,
 
     /// Disable yield eligibility for a token account.
     ///
-    /// This instruction allows the yield authority to revoke yield claim eligibility
-    /// from a token account. Once disabled, only the yield authority can claim yield
-    /// for this account.
+    /// This instruction allows revoking yield claim eligibility from a token account.
+    /// Once disabled, the account owner cannot claim yield directly using ClaimYieldTo
+    /// unless a yield authority exists to authorize the claim.
+    ///
+    /// Authorization:
+    /// - If a yield authority is set on the mint, the yield authority must sign
+    /// - If no yield authority is set, the token account owner must sign
     ///
     /// Fails if:
-    /// - No yield authority is set on the mint
     /// - The account is already not yield-eligible
-    /// - The signer is not the yield authority
+    /// - The signer is not the required authority (yield authority or owner)
     ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single authority
     ///   0. `[writable]` The token account to disable yield for.
     ///   1. `[]` The mint account.
-    ///   2. `[signer]` The mint's yield authority.
+    ///   2. `[signer]` The yield authority (if set) or token account owner (if not).
     ///
     ///   * Multisignature authority
     ///   0. `[writable]` The token account to disable yield for.
     ///   1. `[]` The mint account.
-    ///   2. `[]` The mint's multisignature yield authority.
+    ///   2. `[]` The multisignature yield authority or token account owner.
     ///   3. `..3+M` `[signer]` M signer accounts.
     DisableYield,
 

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -11,10 +11,7 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
-    spl_pod::{
-        optional_keys::OptionalNonZeroPubkey,
-        primitives::{PodBool, PodU64},
-    },
+    spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodU64},
     std::convert::TryInto,
 };
 
@@ -62,31 +59,6 @@ pub enum ClaimableYieldInstruction {
     /// Data expected by this instruction:
     ///   `crate::extension::claimable_yield::instruction::UpdateIndexInstructionData`
     UpdateIndex,
-
-    /// Configure a token account for claimable yield.
-    ///
-    /// The instruction fails if the claimable yield extension is already
-    /// configured, or if the mint was not initialized with claimable
-    /// yield support.
-    ///
-    /// The instruction fails if the `TokenInstruction::InitializeAccount`
-    /// instruction has not yet successfully executed for the token account.
-    ///
-    /// Upon success, yield accrual is enabled for this account starting
-    /// from the current global index.
-    ///
-    /// Accounts expected by this instruction:
-    ///
-    ///   0. `[writable]` The token account to configure.
-    ///   1. `[]` The mint account (to read global index).
-    ///   2. `[signer]` The account's owner.
-    ///
-    ///   * Multisignature authority
-    ///   0. `[writable]` The token account to configure.
-    ///   1. `[]` The mint account.
-    ///   2. `[]` The account's multisignature owner.
-    ///   3. `..3+M` `[signer]` M signer accounts.
-    ConfigureAccount,
 
     /// Claim all accrued yield for a token account.
     ///
@@ -138,16 +110,6 @@ pub struct UpdateIndexInstructionData {
     pub new_index: PodU64,
 }
 
-/// Data expected by `ClaimableYieldInstruction::ConfigureAccount`
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[derive(Clone, Copy, Pod, Zeroable)]
-#[repr(C)]
-pub struct ConfigureAccountInstructionData {
-    /// Whether the account owner is eligible to collect yield
-    pub yield_eligible: PodBool,
-}
-
 /// Create an `InitializeMint` instruction
 pub fn initialize_mint(
     token_program_id: &Pubkey,
@@ -194,35 +156,6 @@ pub fn update_index(
         ClaimableYieldInstruction::UpdateIndex,
         &UpdateIndexInstructionData {
             new_index: new_index.into(),
-        },
-    ))
-}
-
-/// Create a `ConfigureAccount` instruction
-pub fn configure_account(
-    token_program_id: &Pubkey,
-    account: &Pubkey,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    signers: &[&Pubkey],
-    yield_eligible: bool,
-) -> Result<Instruction, ProgramError> {
-    check_program_account(token_program_id)?;
-    let mut accounts = vec![
-        AccountMeta::new(*account, false),
-        AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(*owner, signers.is_empty()),
-    ];
-    for signer_pubkey in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
-    }
-    Ok(encode_instruction(
-        token_program_id,
-        accounts,
-        TokenInstruction::ClaimableYieldExtension,
-        ClaimableYieldInstruction::ConfigureAccount,
-        &ConfigureAccountInstructionData {
-            yield_eligible: PodBool::from(yield_eligible),
         },
     ))
 }

--- a/interface/src/extension/claimable_yield/instruction.rs
+++ b/interface/src/extension/claimable_yield/instruction.rs
@@ -63,6 +63,31 @@ pub enum ClaimableYieldInstruction {
     ///   3. `..3+M` `[signer]` M signer accounts.
     EnableYield,
 
+    /// Disable yield eligibility for a token account.
+    ///
+    /// This instruction allows the yield authority to revoke yield claim eligibility
+    /// from a token account. Once disabled, only the yield authority can claim yield
+    /// for this account.
+    ///
+    /// Fails if:
+    /// - No yield authority is set on the mint
+    /// - The account is already not yield-eligible
+    /// - The signer is not the yield authority
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The token account to disable yield for.
+    ///   1. `[]` The mint account.
+    ///   2. `[signer]` The mint's yield authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The token account to disable yield for.
+    ///   1. `[]` The mint account.
+    ///   2. `[]` The mint's multisignature yield authority.
+    ///   3. `..3+M` `[signer]` M signer accounts.
+    DisableYield,
+
     /// Update the global yield index. Only supported for mints that include the
     /// `ClaimableYield` extension.
     ///
@@ -180,6 +205,32 @@ pub fn enable_yield(
         accounts,
         TokenInstruction::ClaimableYieldExtension,
         ClaimableYieldInstruction::EnableYield,
+        &{},
+    ))
+}
+
+/// Create a `DisableYield` instruction
+pub fn disable_yield(
+    token_program_id: &Pubkey,
+    account: &Pubkey,
+    mint: &Pubkey,
+    yield_authority: &Pubkey,
+    signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*account, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*yield_authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ClaimableYieldExtension,
+        ClaimableYieldInstruction::DisableYield,
         &{},
     ))
 }

--- a/interface/src/extension/claimable_yield/mod.rs
+++ b/interface/src/extension/claimable_yield/mod.rs
@@ -46,6 +46,10 @@ pub fn calculate_yield(
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ClaimableYieldConfig {
+    /// Who is allowed to actually lcaim
+    /// If token account is opted out, this would be eligible to claim, whether a "yield auth" is defined or not
+    pub claim_authority: OptionalNonZeroPubkey,
+    /// Who can flip the "yield eligible" bool
     /// Authority which determines which accounts can claim yield
     pub yield_authority: OptionalNonZeroPubkey,
     /// Authority that can update the global index

--- a/interface/src/extension/claimable_yield/mod.rs
+++ b/interface/src/extension/claimable_yield/mod.rs
@@ -51,7 +51,7 @@ pub struct ClaimableYieldConfig {
     pub claim_authority: OptionalNonZeroPubkey,
     /// Who can flip the "yield eligible" bool
     /// Authority which determines which accounts can claim yield
-    pub yield_authority: OptionalNonZeroPubkey,
+    pub eligibility_authority: OptionalNonZeroPubkey,
     /// Authority that can update the global index
     pub index_authority: OptionalNonZeroPubkey,
     /// Global yield index (fixed-point representation with 9 decimal places)

--- a/interface/src/extension/claimable_yield/mod.rs
+++ b/interface/src/extension/claimable_yield/mod.rs
@@ -94,6 +94,11 @@ impl ClaimableYieldAccount {
         self.yield_eligible = PodBool::from(eligible);
     }
 
+    /// Gets the yield eligibility status
+    pub fn get_yield_eligible(&self) -> bool {
+        self.yield_eligible.into()
+    }
+
     /// Get the pending amount as a u64
     pub fn get_pending_amount(&self) -> u64 {
         self.pending_amount.into()

--- a/interface/src/extension/claimable_yield/mod.rs
+++ b/interface/src/extension/claimable_yield/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use spl_pod::primitives::PodBool;
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
@@ -45,6 +46,8 @@ pub fn calculate_yield(
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ClaimableYieldConfig {
+    /// Authority which determines which accounts can claim yield
+    pub yield_authority: OptionalNonZeroPubkey,
     /// Authority that can update the global index
     pub index_authority: OptionalNonZeroPubkey,
     /// Global yield index (fixed-point representation with 9 decimal places)
@@ -81,9 +84,16 @@ pub struct ClaimableYieldAccount {
     pub pending_amount: PodU64,
     /// Local copy of the global index when this account was last updated
     pub local_index: PodU64,
+    /// Whether the owner of this account is eligible to claim yield
+    pub yield_eligible: PodBool,
 }
 
 impl ClaimableYieldAccount {
+    /// Set the yield eligibility status
+    pub fn set_yield_eligible(&mut self, eligible: bool) {
+        self.yield_eligible = PodBool::from(eligible);
+    }
+
     /// Get the pending amount as a u64
     pub fn get_pending_amount(&self) -> u64 {
         self.pending_amount.into()

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -775,6 +775,9 @@ pub trait BaseStateWithExtensionsMut<S: BaseState>: BaseStateWithExtensions<S> {
             ExtensionType::PausableAccount => {
                 self.init_extension::<PausableAccount>(true).map(|_| ())
             }
+            ExtensionType::ClaimableYieldAccount => self
+                .init_extension::<ClaimableYieldAccount>(true)
+                .map(|_| ()),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => {
                 self.init_extension::<AccountPaddingTest>(true).map(|_| ())
@@ -1318,6 +1321,9 @@ impl ExtensionType {
                 }
                 ExtensionType::Pausable => {
                     account_extension_types.push(ExtensionType::PausableAccount);
+                }
+                ExtensionType::ClaimableYieldConfig => {
+                    account_extension_types.push(ExtensionType::ClaimableYieldAccount);
                 }
                 #[cfg(test)]
                 ExtensionType::MintPaddingTest => {

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1162,8 +1162,10 @@ pub enum AuthorityType {
     Pause,
     /// Authority to update the global yield index
     ClaimableYieldIndex,
-    /// Authority to change the mint's yield admin
-    ClaimableYieldAdmin,
+    /// Authority to set yield claim eligiblity for token accounts of this mint
+    ClaimableYieldEligiblity,
+    /// Authority to claim yield accruals for ineligible token accounts of this mint
+    ClaimableYieldClaim,
 }
 
 impl AuthorityType {
@@ -1187,7 +1189,8 @@ impl AuthorityType {
             AuthorityType::ScaledUiAmount => 15,
             AuthorityType::Pause => 16,
             AuthorityType::ClaimableYieldIndex => 17,
-            AuthorityType::ClaimableYieldAdmin => 18,
+            AuthorityType::ClaimableYieldEligiblity => 18,
+            AuthorityType::ClaimableYieldClaim => 19,
         }
     }
 
@@ -1212,7 +1215,8 @@ impl AuthorityType {
             15 => Ok(AuthorityType::ScaledUiAmount),
             16 => Ok(AuthorityType::Pause),
             17 => Ok(AuthorityType::ClaimableYieldIndex),
-            18 => Ok(AuthorityType::ClaimableYieldAdmin),
+            18 => Ok(AuthorityType::ClaimableYieldEligiblity),
+            19 => Ok(AuthorityType::ClaimableYieldClaim),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -1162,6 +1162,8 @@ pub enum AuthorityType {
     Pause,
     /// Authority to update the global yield index
     ClaimableYieldIndex,
+    /// Authority to change the mint's yield admin
+    ClaimableYieldAdmin,
 }
 
 impl AuthorityType {
@@ -1185,6 +1187,7 @@ impl AuthorityType {
             AuthorityType::ScaledUiAmount => 15,
             AuthorityType::Pause => 16,
             AuthorityType::ClaimableYieldIndex => 17,
+            AuthorityType::ClaimableYieldAdmin => 18,
         }
     }
 
@@ -1209,6 +1212,7 @@ impl AuthorityType {
             15 => Ok(AuthorityType::ScaledUiAmount),
             16 => Ok(AuthorityType::Pause),
             17 => Ok(AuthorityType::ClaimableYieldIndex),
+            18 => Ok(AuthorityType::ClaimableYieldAdmin),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -79,50 +79,6 @@ fn process_update_index(
     Ok(())
 }
 
-fn process_configure_account(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let account_info_iter = &mut accounts.iter();
-    let token_account_info = next_account_info(account_info_iter)?;
-    let mint_account_info = next_account_info(account_info_iter)?;
-    let owner_info = next_account_info(account_info_iter)?;
-    let owner_info_data_len = owner_info.data_len();
-
-    // First, get the global index from the mint
-    let mut mint_data = mint_account_info.data.borrow_mut();
-    let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
-    let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
-    let global_index = mint_extension.get_global_index();
-    drop(mint_data);
-
-    // Now configure the token account
-    let mut token_account_data = token_account_info.data.borrow_mut();
-    let mut token_account =
-        PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
-
-    // Validate owner
-    Processor::validate_owner(
-        program_id,
-        &token_account.base.owner,
-        owner_info,
-        owner_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
-
-    // Check if extension already exists
-    if token_account
-        .get_extension::<ClaimableYieldAccount>()
-        .is_ok()
-    {
-        return Err(TokenError::ExtensionAlreadyInitialized.into());
-    }
-
-    // Initialize the extension with current global index
-    let extension = token_account.init_extension::<ClaimableYieldAccount>(false)?;
-    extension.set_local_index(global_index);
-    extension.set_pending_amount(0);
-
-    Ok(())
-}
-
 fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
@@ -228,10 +184,6 @@ pub(crate) fn process_instruction(
             msg!("ClaimableYieldInstruction::UpdateIndex");
             let UpdateIndexInstructionData { new_index } = decode_instruction_data(input)?;
             process_update_index(program_id, accounts, u64::from(*new_index))
-        }
-        ClaimableYieldInstruction::ConfigureAccount => {
-            msg!("ClaimableYieldInstruction::ConfigureAccount");
-            process_configure_account(program_id, accounts)
         }
         ClaimableYieldInstruction::ClaimYield => {
             msg!("ClaimableYieldInstruction::ClaimYield");

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -28,7 +28,7 @@ fn process_initialize_mint(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
     claim_authority: &OptionalNonZeroPubkey,
-    yield_authority: &OptionalNonZeroPubkey,
+    eligibility_authority: &OptionalNonZeroPubkey,
     index_authority: &OptionalNonZeroPubkey,
     initial_index: u64,
 ) -> ProgramResult {
@@ -40,7 +40,7 @@ fn process_initialize_mint(
 
     let extension = mint.init_extension::<ClaimableYieldConfig>(true)?;
     extension.claim_authority = *claim_authority;
-    extension.yield_authority = *yield_authority;
+    extension.eligibility_authority = *eligibility_authority;
     extension.index_authority = *index_authority;
     extension.set_global_index(initial_index);
 
@@ -73,12 +73,12 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    match Option::<Pubkey>::from(mint_extension.yield_authority) {
-        Some(yield_authority) => {
+    match Option::<Pubkey>::from(mint_extension.eligibility_authority) {
+        Some(eligibility_authority) => {
             // Yield authority is set, require yield authority signature
             Processor::validate_owner(
                 program_id,
-                &yield_authority,
+                &eligibility_authority,
                 authority_account_info,
                 authority_info_data_len,
                 account_info_iter.as_slice(),
@@ -127,12 +127,12 @@ fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    match Option::<Pubkey>::from(mint_extension.yield_authority) {
-        Some(yield_authority) => {
+    match Option::<Pubkey>::from(mint_extension.eligibility_authority) {
+        Some(eligibility_authority) => {
             // Yield authority is set, require yield authority signature
             Processor::validate_owner(
                 program_id,
-                &yield_authority,
+                &eligibility_authority,
                 authority_account_info,
                 authority_info_data_len,
                 account_info_iter.as_slice(),
@@ -277,7 +277,7 @@ pub(crate) fn process_instruction(
             msg!("ClaimableYieldInstruction::InitializeMint");
             let InitializeInstructionData {
                 claim_authority,
-                yield_authority,
+                eligibility_authority,
                 index_authority,
                 initial_index,
             } = decode_instruction_data(input)?;
@@ -285,7 +285,7 @@ pub(crate) fn process_instruction(
                 program_id,
                 accounts,
                 claim_authority,
-                yield_authority,
+                eligibility_authority,
                 index_authority,
                 u64::from(*initial_index),
             )

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -64,6 +64,11 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     }
     let token_account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
 
+    // If account is already flagged eligible, return an error
+    if token_account_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
+    }
+
     let mint_data = mint_account_info.data.borrow();
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
@@ -89,11 +94,6 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
                 account_info_iter.as_slice(),
             )?;
         }
-    }
-
-    // If account is already flagged eligible, return an error
-    if token_account_extension.get_yield_eligible() {
-        return Err(TokenError::InvalidState.into());
     }
 
     token_account_extension.set_yield_eligible(true);
@@ -118,6 +118,11 @@ fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
     }
     let token_account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
 
+    // If account is already not eligible, return an error
+    if !token_account_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
+    }
+
     let mint_data = mint_account_info.data.borrow();
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
@@ -143,11 +148,6 @@ fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
                 account_info_iter.as_slice(),
             )?;
         }
-    }
-
-    // If account is already not eligible, return an error
-    if !token_account_extension.get_yield_eligible() {
-        return Err(TokenError::InvalidState.into());
     }
 
     token_account_extension.set_yield_eligible(false);

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -27,6 +27,7 @@ use {
 fn process_initialize_mint(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
+    claim_authority: &OptionalNonZeroPubkey,
     yield_authority: &OptionalNonZeroPubkey,
     index_authority: &OptionalNonZeroPubkey,
     initial_index: u64,
@@ -38,6 +39,7 @@ fn process_initialize_mint(
     let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
 
     let extension = mint.init_extension::<ClaimableYieldConfig>(true)?;
+    extension.claim_authority = *claim_authority;
     extension.yield_authority = *yield_authority;
     extension.index_authority = *index_authority;
     extension.set_global_index(initial_index);
@@ -202,13 +204,13 @@ fn process_claim_yield_to(program_id: &Pubkey, accounts: &[AccountInfo]) -> Prog
             account_info_iter.as_slice(),
         )?;
     } else {
-        // Source account is not yield eligible, the mint yield authority must exist and be the signer
-        let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority)
+        // Source account is not yield eligible, the mint claim authority must exist and be the signer
+        let claim_authority = Option::<Pubkey>::from(mint_extension.claim_authority)
             .ok_or(TokenError::NoAuthorityExists)?;
 
         Processor::validate_owner(
             program_id,
-            &yield_authority,
+            &claim_authority,
             authority_info,
             authority_info_data_len,
             account_info_iter.as_slice(),
@@ -246,6 +248,7 @@ pub(crate) fn process_instruction(
         ClaimableYieldInstruction::InitializeMint => {
             msg!("ClaimableYieldInstruction::InitializeMint");
             let InitializeInstructionData {
+                claim_authority,
                 yield_authority,
                 index_authority,
                 initial_index,
@@ -253,6 +256,7 @@ pub(crate) fn process_instruction(
             process_initialize_mint(
                 program_id,
                 accounts,
+                claim_authority,
                 yield_authority,
                 index_authority,
                 u64::from(*initial_index),

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -160,12 +160,12 @@ fn process_update_index(
     Ok(())
 }
 
-fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+fn process_owner_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_info = next_account_info(account_info_iter)?;
-    let owner_info_data_len = yield_authority_info.data_len();
+    let owner_info = next_account_info(account_info_iter)?;
+    let owner_info_data_len = owner_info.data_len();
 
     // Get token account data
     let mut token_account_data = token_account_info.data.borrow_mut();
@@ -173,16 +173,14 @@ fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
     let owner = token_account.base.owner;
 
-    // If yield eligible, verify yield authority is owner
-    // Else, verify provided yield authority matches mint yield authority
-    // Validate owner
-    // Processor::validate_owner(
-    //     program_id,
-    //     &token_account.base.owner,
-    //     yield_authority_info,
-    //     owner_info_data_len,
-    //     account_info_iter.as_slice(),
-    // )?;
+    // Validate owner signature
+    Processor::validate_owner(
+        program_id,
+        &owner,
+        owner_info,
+        owner_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
 
     // Extract account amount before mutable borrow
     let account_amount = u64::from(token_account.base.amount);
@@ -190,32 +188,16 @@ fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
 
-    // Accrue pending yield
+    // Get extensions
     let account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority);
-
-    // Validate the signer based on yield authority and eligibility
-    match yield_authority {
-        Some(auth) if !bool::from(account_extension.yield_eligible) => {
-            // Yield authority is set and account is not marked as eligible, yield authority must be the one claiming yield
-            if *yield_authority_info.key != auth {
-                return Err(TokenError::AuthorityTypeNotSupported.into());
-            }
-        }
-        _ => {
-            // Either yield authority is not set or account is flagged as eligible for yield collection, verify token account owner is collecting yield
-            Processor::validate_owner(
-                program_id,
-                &owner,
-                yield_authority_info,
-                owner_info_data_len,
-                account_info_iter.as_slice(),
-            )?;
-        }
+    // Verify account is yield-eligible
+    if !account_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
     }
 
+    // Accrue pending yield
     account_extension.accrue_pending_yield(account_amount, mint_extension.get_global_index())?;
 
     let total_yield = account_extension.get_pending_amount();
@@ -231,6 +213,86 @@ fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
 
         // Update token account balance
         token_account.base.amount = u64::from(token_account.base.amount)
+            .checked_add(total_yield)
+            .ok_or(TokenError::Overflow)?
+            .into();
+    }
+
+    Ok(())
+}
+
+fn process_authority_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let source_account_info = next_account_info(account_info_iter)?;
+    let target_account_info = next_account_info(account_info_iter)?;
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let yield_authority_info = next_account_info(account_info_iter)?;
+    let yield_authority_info_data_len = yield_authority_info.data_len();
+
+    // Get source token account data
+    let mut source_account_data = source_account_info.data.borrow_mut();
+    let mut source_account =
+        PodStateWithExtensionsMut::<PodAccount>::unpack(&mut source_account_data)?;
+
+    // Verify source account belongs to mint
+    if source_account.base.mint != *mint_account_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+
+    // Get target token account data
+    let mut target_account_data = target_account_info.data.borrow_mut();
+    let target_account = PodStateWithExtensionsMut::<PodAccount>::unpack(&mut target_account_data)?;
+
+    // Verify target account belongs to same mint
+    if target_account.base.mint != *mint_account_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+
+    // Extract source account amount before mutable borrow
+    let source_account_amount = u64::from(source_account.base.amount);
+
+    // Get mint data
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
+    let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
+
+    // Verify yield authority exists and validate signature
+    let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority)
+        .ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &yield_authority,
+        yield_authority_info,
+        yield_authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    // Get source account extension
+    let source_extension = source_account.get_extension_mut::<ClaimableYieldAccount>()?;
+
+    // Verify source account is NOT yield-eligible (authority can only claim for non-eligible)
+    if source_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
+    }
+
+    // Accrue pending yield on source account
+    source_extension
+        .accrue_pending_yield(source_account_amount, mint_extension.get_global_index())?;
+
+    let total_yield = source_extension.get_pending_amount();
+    if total_yield > 0 {
+        // Reset source pending amount
+        source_extension.reset_pending_amount();
+
+        // Update mint supply
+        mint.base.supply = u64::from(mint.base.supply)
+            .checked_add(total_yield)
+            .ok_or(TokenError::Overflow)?
+            .into();
+
+        // Add minted tokens to target account balance
+        target_account.base.amount = u64::from(target_account.base.amount)
             .checked_add(total_yield)
             .ok_or(TokenError::Overflow)?
             .into();
@@ -269,14 +331,18 @@ pub(crate) fn process_instruction(
             msg!("ClaimableYieldInstruction::DisableYield");
             process_disable_yield(program_id, accounts)
         }
+        ClaimableYieldInstruction::OwnerClaimYield => {
+            msg!("ClaimableYieldInstruction::OwnerClaimYield");
+            process_owner_claim_yield(program_id, accounts)
+        }
+        ClaimableYieldInstruction::AuthorityClaimYield => {
+            msg!("ClaimableYieldInstruction::AuthorityClaimYield");
+            process_authority_claim_yield(program_id, accounts)
+        }
         ClaimableYieldInstruction::UpdateIndex => {
             msg!("ClaimableYieldInstruction::UpdateIndex");
             let UpdateIndexInstructionData { new_index } = decode_instruction_data(input)?;
             process_update_index(program_id, accounts, u64::from(*new_index))
-        }
-        ClaimableYieldInstruction::ClaimYield => {
-            msg!("ClaimableYieldInstruction::ClaimYield");
-            process_claim_yield(program_id, accounts)
         }
     }
 }

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -51,12 +51,14 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_info_data_len = yield_authority_account_info.data_len();
+    let authority_account_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_account_info.data_len();
 
     let mut token_account_data = token_account_info.data.borrow_mut();
     let mut token_account =
         PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
+    let token_account_owner = token_account.base.owner;
+
     if token_account.base.mint != *mint_account_info.key {
         return Err(TokenError::MintMismatch.into());
     }
@@ -66,16 +68,28 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    let authority = Option::<Pubkey>::from(mint_extension.yield_authority)
-        .ok_or(TokenError::NoAuthorityExists)?;
-
-    Processor::validate_owner(
-        program_id,
-        &authority,
-        yield_authority_account_info,
-        yield_authority_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
+    match Option::<Pubkey>::from(mint_extension.yield_authority) {
+        Some(yield_authority) => {
+            // Yield authority is set, require yield authority signature
+            Processor::validate_owner(
+                program_id,
+                &yield_authority,
+                authority_account_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?;
+        }
+        None => {
+            // No yield authority set, require token account owner signature
+            Processor::validate_owner(
+                program_id,
+                &token_account_owner,
+                authority_account_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?;
+        }
+    }
 
     // If account is already flagged eligible, return an error
     if token_account_extension.get_yield_eligible() {
@@ -91,12 +105,14 @@ fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_info_data_len = yield_authority_account_info.data_len();
+    let authority_account_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_account_info.data_len();
 
     let mut token_account_data = token_account_info.data.borrow_mut();
     let mut token_account =
         PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
+    let token_account_owner = token_account.base.owner;
+
     if token_account.base.mint != *mint_account_info.key {
         return Err(TokenError::MintMismatch.into());
     }
@@ -106,16 +122,28 @@ fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    let authority = Option::<Pubkey>::from(mint_extension.yield_authority)
-        .ok_or(TokenError::NoAuthorityExists)?;
-
-    Processor::validate_owner(
-        program_id,
-        &authority,
-        yield_authority_account_info,
-        yield_authority_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
+    match Option::<Pubkey>::from(mint_extension.yield_authority) {
+        Some(yield_authority) => {
+            // Yield authority is set, require yield authority signature
+            Processor::validate_owner(
+                program_id,
+                &yield_authority,
+                authority_account_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?;
+        }
+        None => {
+            // No yield authority set, require token account owner signature
+            Processor::validate_owner(
+                program_id,
+                &token_account_owner,
+                authority_account_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?;
+        }
+    }
 
     // If account is already not eligible, return an error
     if !token_account_extension.get_yield_eligible() {

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -21,6 +21,7 @@ use {
     solana_program_error::ProgramResult,
     solana_pubkey::Pubkey,
     spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_2022_interface::extension::PodStateWithExtensions,
 };
 
 fn process_initialize_mint(
@@ -40,6 +41,46 @@ fn process_initialize_mint(
     extension.yield_authority = *yield_authority;
     extension.index_authority = *index_authority;
     extension.set_global_index(initial_index);
+
+    Ok(())
+}
+
+fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let yield_authority_account_info = next_account_info(account_info_iter)?;
+    let yield_authority_info_data_len = yield_authority_account_info.data_len();
+
+    let mut token_account_data = token_account_info.data.borrow_mut();
+    let mut token_account =
+        PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
+    if token_account.base.mint != *mint_account_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+    let token_account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
+
+    let mint_data = mint_account_info.data.borrow();
+    let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
+    let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
+
+    let authority = Option::<Pubkey>::from(mint_extension.yield_authority)
+        .ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        yield_authority_account_info,
+        yield_authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    // If account is already flagged eligible, return an error
+    if token_account_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
+    }
+
+    token_account_extension.set_yield_eligible(true);
 
     Ok(())
 }
@@ -179,6 +220,10 @@ pub(crate) fn process_instruction(
                 index_authority,
                 u64::from(*initial_index),
             )
+        }
+        ClaimableYieldInstruction::EnableYield => {
+            msg!("ClaimableYieldInstruction::EnableYield");
+            process_enable_yield(program_id, accounts)
         }
         ClaimableYieldInstruction::UpdateIndex => {
             msg!("ClaimableYieldInstruction::UpdateIndex");

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -160,138 +160,73 @@ fn process_update_index(
     Ok(())
 }
 
-fn process_owner_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let account_info_iter = &mut accounts.iter();
-    let token_account_info = next_account_info(account_info_iter)?;
-    let mint_account_info = next_account_info(account_info_iter)?;
-    let owner_info = next_account_info(account_info_iter)?;
-    let owner_info_data_len = owner_info.data_len();
-
-    // Get token account data
-    let mut token_account_data = token_account_info.data.borrow_mut();
-    let mut token_account =
-        PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
-    let owner = token_account.base.owner;
-
-    // Validate owner signature
-    Processor::validate_owner(
-        program_id,
-        &owner,
-        owner_info,
-        owner_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
-
-    // Extract account amount before mutable borrow
-    let account_amount = u64::from(token_account.base.amount);
-
-    let mut mint_data = mint_account_info.data.borrow_mut();
-    let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
-
-    // Get extensions
-    let account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
-    let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
-
-    // Verify account is yield-eligible
-    if !account_extension.get_yield_eligible() {
-        return Err(TokenError::InvalidState.into());
-    }
-
-    // Accrue pending yield
-    account_extension.accrue_pending_yield(account_amount, mint_extension.get_global_index())?;
-
-    let total_yield = account_extension.get_pending_amount();
-    if total_yield > 0 {
-        // Reset pending amount
-        account_extension.reset_pending_amount();
-
-        // Update mint supply
-        mint.base.supply = u64::from(mint.base.supply)
-            .checked_add(total_yield)
-            .ok_or(TokenError::Overflow)?
-            .into();
-
-        // Update token account balance
-        token_account.base.amount = u64::from(token_account.base.amount)
-            .checked_add(total_yield)
-            .ok_or(TokenError::Overflow)?
-            .into();
-    }
-
-    Ok(())
-}
-
-fn process_authority_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+fn process_claim_yield_to(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let source_account_info = next_account_info(account_info_iter)?;
     let target_account_info = next_account_info(account_info_iter)?;
     let mint_account_info = next_account_info(account_info_iter)?;
-    let yield_authority_info = next_account_info(account_info_iter)?;
-    let yield_authority_info_data_len = yield_authority_info.data_len();
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
 
-    // Get source token account data
     let mut source_account_data = source_account_info.data.borrow_mut();
     let mut source_account =
         PodStateWithExtensionsMut::<PodAccount>::unpack(&mut source_account_data)?;
+    // Extract source amount and owner before mutable borrow
+    let source_account_owner = source_account.base.owner;
+    let source_account_amount = u64::from(source_account.base.amount);
 
-    // Verify source account belongs to mint
     if source_account.base.mint != *mint_account_info.key {
         return Err(TokenError::MintMismatch.into());
     }
 
-    // Get target token account data
     let mut target_account_data = target_account_info.data.borrow_mut();
     let target_account = PodStateWithExtensionsMut::<PodAccount>::unpack(&mut target_account_data)?;
 
-    // Verify target account belongs to same mint
     if target_account.base.mint != *mint_account_info.key {
         return Err(TokenError::MintMismatch.into());
     }
 
-    // Extract source account amount before mutable borrow
-    let source_account_amount = u64::from(source_account.base.amount);
-
-    // Get mint data
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
 
-    // Verify yield authority exists and validate signature
-    let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority)
-        .ok_or(TokenError::NoAuthorityExists)?;
-
-    Processor::validate_owner(
-        program_id,
-        &yield_authority,
-        yield_authority_info,
-        yield_authority_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
-
-    // Get source account extension
     let source_extension = source_account.get_extension_mut::<ClaimableYieldAccount>()?;
 
-    // Verify source account is NOT yield-eligible (authority can only claim for non-eligible)
     if source_extension.get_yield_eligible() {
-        return Err(TokenError::InvalidState.into());
+        // Source account is yield eligible, the token account owner must be the signer
+        Processor::validate_owner(
+            program_id,
+            &source_account_owner,
+            authority_info,
+            authority_info_data_len,
+            account_info_iter.as_slice(),
+        )?;
+    } else {
+        // Source account is not yield eligible, the mint yield authority must exist and be the signer
+        let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority)
+            .ok_or(TokenError::NoAuthorityExists)?;
+
+        Processor::validate_owner(
+            program_id,
+            &yield_authority,
+            authority_info,
+            authority_info_data_len,
+            account_info_iter.as_slice(),
+        )?;
     }
 
-    // Accrue pending yield on source account
     source_extension
         .accrue_pending_yield(source_account_amount, mint_extension.get_global_index())?;
 
     let total_yield = source_extension.get_pending_amount();
     if total_yield > 0 {
-        // Reset source pending amount
         source_extension.reset_pending_amount();
 
-        // Update mint supply
         mint.base.supply = u64::from(mint.base.supply)
             .checked_add(total_yield)
             .ok_or(TokenError::Overflow)?
             .into();
 
-        // Add minted tokens to target account balance
         target_account.base.amount = u64::from(target_account.base.amount)
             .checked_add(total_yield)
             .ok_or(TokenError::Overflow)?
@@ -331,13 +266,9 @@ pub(crate) fn process_instruction(
             msg!("ClaimableYieldInstruction::DisableYield");
             process_disable_yield(program_id, accounts)
         }
-        ClaimableYieldInstruction::OwnerClaimYield => {
-            msg!("ClaimableYieldInstruction::OwnerClaimYield");
-            process_owner_claim_yield(program_id, accounts)
-        }
-        ClaimableYieldInstruction::AuthorityClaimYield => {
-            msg!("ClaimableYieldInstruction::AuthorityClaimYield");
-            process_authority_claim_yield(program_id, accounts)
+        ClaimableYieldInstruction::ClaimYieldTo => {
+            msg!("ClaimableYieldInstruction::ClaimYieldTo");
+            process_claim_yield_to(program_id, accounts)
         }
         ClaimableYieldInstruction::UpdateIndex => {
             msg!("ClaimableYieldInstruction::UpdateIndex");

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -85,6 +85,46 @@ fn process_enable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     Ok(())
 }
 
+fn process_disable_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let yield_authority_account_info = next_account_info(account_info_iter)?;
+    let yield_authority_info_data_len = yield_authority_account_info.data_len();
+
+    let mut token_account_data = token_account_info.data.borrow_mut();
+    let mut token_account =
+        PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
+    if token_account.base.mint != *mint_account_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+    let token_account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
+
+    let mint_data = mint_account_info.data.borrow();
+    let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
+    let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
+
+    let authority = Option::<Pubkey>::from(mint_extension.yield_authority)
+        .ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        yield_authority_account_info,
+        yield_authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    // If account is already not eligible, return an error
+    if !token_account_extension.get_yield_eligible() {
+        return Err(TokenError::InvalidState.into());
+    }
+
+    token_account_extension.set_yield_eligible(false);
+
+    Ok(())
+}
+
 fn process_update_index(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -224,6 +264,10 @@ pub(crate) fn process_instruction(
         ClaimableYieldInstruction::EnableYield => {
             msg!("ClaimableYieldInstruction::EnableYield");
             process_enable_yield(program_id, accounts)
+        }
+        ClaimableYieldInstruction::DisableYield => {
+            msg!("ClaimableYieldInstruction::DisableYield");
+            process_disable_yield(program_id, accounts)
         }
         ClaimableYieldInstruction::UpdateIndex => {
             msg!("ClaimableYieldInstruction::UpdateIndex");

--- a/program/src/extension/claimable_yield/processor.rs
+++ b/program/src/extension/claimable_yield/processor.rs
@@ -26,6 +26,7 @@ use {
 fn process_initialize_mint(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
+    yield_authority: &OptionalNonZeroPubkey,
     index_authority: &OptionalNonZeroPubkey,
     initial_index: u64,
 ) -> ProgramResult {
@@ -36,6 +37,7 @@ fn process_initialize_mint(
     let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
 
     let extension = mint.init_extension::<ClaimableYieldConfig>(true)?;
+    extension.yield_authority = *yield_authority;
     extension.index_authority = *index_authority;
     extension.set_global_index(initial_index);
 
@@ -125,22 +127,25 @@ fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_account_info = next_account_info(account_info_iter)?;
-    let owner_info = next_account_info(account_info_iter)?;
-    let owner_info_data_len = owner_info.data_len();
+    let yield_authority_info = next_account_info(account_info_iter)?;
+    let owner_info_data_len = yield_authority_info.data_len();
 
     // Get token account data
     let mut token_account_data = token_account_info.data.borrow_mut();
     let mut token_account =
         PodStateWithExtensionsMut::<PodAccount>::unpack(&mut token_account_data)?;
+    let owner = token_account.base.owner;
 
+    // If yield eligible, verify yield authority is owner
+    // Else, verify provided yield authority matches mint yield authority
     // Validate owner
-    Processor::validate_owner(
-        program_id,
-        &token_account.base.owner,
-        owner_info,
-        owner_info_data_len,
-        account_info_iter.as_slice(),
-    )?;
+    // Processor::validate_owner(
+    //     program_id,
+    //     &token_account.base.owner,
+    //     yield_authority_info,
+    //     owner_info_data_len,
+    //     account_info_iter.as_slice(),
+    // )?;
 
     // Extract account amount before mutable borrow
     let account_amount = u64::from(token_account.base.amount);
@@ -151,6 +156,28 @@ fn process_claim_yield(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
     // Accrue pending yield
     let account_extension = token_account.get_extension_mut::<ClaimableYieldAccount>()?;
     let mint_extension = mint.get_extension::<ClaimableYieldConfig>()?;
+
+    let yield_authority = Option::<Pubkey>::from(mint_extension.yield_authority);
+
+    // Validate the signer based on yield authority and eligibility
+    match yield_authority {
+        Some(auth) if !bool::from(account_extension.yield_eligible) => {
+            // Yield authority is set and account is not marked as eligible, yield authority must be the one claiming yield
+            if *yield_authority_info.key != auth {
+                return Err(TokenError::AuthorityTypeNotSupported.into());
+            }
+        }
+        _ => {
+            // Either yield authority is not set or account is flagged as eligible for yield collection, verify token account owner is collecting yield
+            Processor::validate_owner(
+                program_id,
+                &owner,
+                yield_authority_info,
+                owner_info_data_len,
+                account_info_iter.as_slice(),
+            )?;
+        }
+    }
 
     account_extension.accrue_pending_yield(account_amount, mint_extension.get_global_index())?;
 
@@ -185,12 +212,14 @@ pub(crate) fn process_instruction(
         ClaimableYieldInstruction::InitializeMint => {
             msg!("ClaimableYieldInstruction::InitializeMint");
             let InitializeInstructionData {
+                yield_authority,
                 index_authority,
                 initial_index,
             } = decode_instruction_data(input)?;
             process_initialize_mint(
                 program_id,
                 accounts,
+                yield_authority,
                 index_authority,
                 u64::from(*initial_index),
             )

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -196,19 +196,6 @@ impl Processor {
             account.init_account_extension_from_type(extension)?;
         }
 
-        if let Ok(mint_yield_config) = mint.get_extension::<ClaimableYieldConfig>() {
-            if let Ok(account_yield_extension) =
-                account.get_extension_mut::<ClaimableYieldAccount>()
-            {
-                account_yield_extension.set_local_index(mint_yield_config.get_global_index());
-
-                // If no yield authority is set, account is eligible by default (permissionless)
-                let yield_eligible =
-                    Option::<Pubkey>::from(mint_yield_config.yield_authority).is_none();
-                account_yield_extension.set_yield_eligible(yield_eligible);
-            }
-        }
-
         let starting_state =
             if let Ok(default_account_state) = mint.get_extension::<DefaultAccountState>() {
                 AccountState::try_from(default_account_state.state)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -196,6 +196,14 @@ impl Processor {
             account.init_account_extension_from_type(extension)?;
         }
 
+        if let Ok(mint_yield_config) = mint.get_extension::<ClaimableYieldConfig>() {
+            if let Ok(account_yield_extension) =
+                account.get_extension_mut::<ClaimableYieldAccount>()
+            {
+                account_yield_extension.set_local_index(mint_yield_config.get_global_index());
+            }
+        }
+
         let starting_state =
             if let Ok(default_account_state) = mint.get_extension::<DefaultAccountState>() {
                 AccountState::try_from(default_account_state.state)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1002,7 +1002,7 @@ impl Processor {
                 }
                 AuthorityType::ClaimableYieldEligiblity => {
                     let extension = mint.get_extension_mut::<ClaimableYieldConfig>()?;
-                    let maybe_authority: Option<Pubkey> = extension.yield_authority.into();
+                    let maybe_authority: Option<Pubkey> = extension.eligibility_authority.into();
                     let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
                     Self::validate_owner(
                         program_id,
@@ -1011,7 +1011,7 @@ impl Processor {
                         authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
-                    extension.yield_authority = new_authority.try_into()?;
+                    extension.eligibility_authority = new_authority.try_into()?;
                 }
                 AuthorityType::ClaimableYieldClaim => {
                     let extension = mint.get_extension_mut::<ClaimableYieldConfig>()?;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -201,6 +201,11 @@ impl Processor {
                 account.get_extension_mut::<ClaimableYieldAccount>()
             {
                 account_yield_extension.set_local_index(mint_yield_config.get_global_index());
+
+                // If no yield authority is set, account is eligible by default (permissionless)
+                let yield_eligible =
+                    Option::<Pubkey>::from(mint_yield_config.yield_authority).is_none();
+                account_yield_extension.set_yield_eligible(yield_eligible);
             }
         }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1013,7 +1013,7 @@ impl Processor {
                     )?;
                     extension.index_authority = new_authority.try_into()?;
                 }
-                AuthorityType::ClaimableYieldAdmin => {
+                AuthorityType::ClaimableYieldEligiblity => {
                     let extension = mint.get_extension_mut::<ClaimableYieldConfig>()?;
                     let maybe_authority: Option<Pubkey> = extension.yield_authority.into();
                     let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
@@ -1025,6 +1025,19 @@ impl Processor {
                         account_info_iter.as_slice(),
                     )?;
                     extension.yield_authority = new_authority.try_into()?;
+                }
+                AuthorityType::ClaimableYieldClaim => {
+                    let extension = mint.get_extension_mut::<ClaimableYieldConfig>()?;
+                    let maybe_authority: Option<Pubkey> = extension.claim_authority.into();
+                    let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+                    Self::validate_owner(
+                        program_id,
+                        &authority,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?;
+                    extension.claim_authority = new_authority.try_into()?;
                 }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1008,6 +1008,19 @@ impl Processor {
                     )?;
                     extension.index_authority = new_authority.try_into()?;
                 }
+                AuthorityType::ClaimableYieldAdmin => {
+                    let extension = mint.get_extension_mut::<ClaimableYieldConfig>()?;
+                    let maybe_authority: Option<Pubkey> = extension.yield_authority.into();
+                    let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+                    Self::validate_owner(
+                        program_id,
+                        &authority,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?;
+                    extension.yield_authority = new_authority.try_into()?;
+                }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }


### PR DESCRIPTION
- Claimable yield mint supports an optional yield authority
- If yield authority is set, authority may flag accounts as yield eligible
- If yield auth set and account is not eligible for yield collection, yield authority may collect any accrued yield